### PR TITLE
펫 체력 및 넉다운(사망) 구현

### DIFF
--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/100_Dog_Nomal.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/100_Dog_Nomal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -474448489328772740}
   m_Layer: 0
   m_Name: 100_Dog_Nomal
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3
   attackDamage: 10
   attackCooldown: 5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-474448489328772740
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/101_Dog_Rare.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/101_Dog_Rare.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 5815627764430580793}
   m_Layer: 0
   m_Name: 101_Dog_Rare
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3.5
   attackDamage: 20
   attackCooldown: 4
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &5815627764430580793
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/102_Dog_Epic.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/102_Dog_Epic.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -1258412424632940354}
   m_Layer: 0
   m_Name: 102_Dog_Epic
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4
   attackDamage: 30
-  attackCooldown: 3
+  attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-1258412424632940354
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/103_Dog_Unique.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/103_Dog_Unique.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -3308915197720117924}
   m_Layer: 0
   m_Name: 103_Dog_Unique
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4.5
   attackDamage: 40
   attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-3308915197720117924
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/104_Dog_Legendary.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/104_Dog_Legendary.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 5074094339627599451}
   m_Layer: 0
   m_Name: 104_Dog_Legendary
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 5
   attackDamage: 50
   attackCooldown: 1
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &5074094339627599451
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/200_Cat_Nomal.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/200_Cat_Nomal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -5041671731241346243}
   m_Layer: 0
   m_Name: 200_Cat_Nomal
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3
   attackDamage: 10
   attackCooldown: 5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-5041671731241346243
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/201_Cat_Rare.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/201_Cat_Rare.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -7803620267539452916}
   m_Layer: 0
   m_Name: 201_Cat_Rare
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3.5
   attackDamage: 20
   attackCooldown: 4
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-7803620267539452916
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/202_Cat_Epic.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/202_Cat_Epic.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -1934317435960231069}
   m_Layer: 0
   m_Name: 202_Cat_Epic
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4
   attackDamage: 30
   attackCooldown: 3
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-1934317435960231069
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/203_Cat_Unique.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/203_Cat_Unique.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -1455324863758323217}
   m_Layer: 0
   m_Name: 203_Cat_Unique
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4.5
   attackDamage: 4
   attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-1455324863758323217
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/204_Cat_Legendary.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/204_Cat_Legendary.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -310383817187209768}
   m_Layer: 0
   m_Name: 204_Cat_Legendary
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 5
   attackDamage: 50
   attackCooldown: 1
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-310383817187209768
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/300_Rabbit_Nomal.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/300_Rabbit_Nomal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -335036399801317654}
   m_Layer: 0
   m_Name: 300_Rabbit_Nomal
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3
   attackDamage: 10
   attackCooldown: 5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-335036399801317654
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/301_Rabbit_Rare.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/301_Rabbit_Rare.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 2168074467651834524}
   m_Layer: 0
   m_Name: 301_Rabbit_Rare
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3.5
   attackDamage: 20
   attackCooldown: 4
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &2168074467651834524
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/302_Rabbit_Epic.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/302_Rabbit_Epic.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -3619468845185503263}
   m_Layer: 0
   m_Name: 302_Rabbit_Epic
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4
   attackDamage: 30
   attackCooldown: 3
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-3619468845185503263
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/303_Rabbit_Unique.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/303_Rabbit_Unique.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -7321777679485425073}
   m_Layer: 0
   m_Name: 303_Rabbit_Unique
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4.5
   attackDamage: 4
   attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-7321777679485425073
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/304_Rabbit_Legendary.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/304_Rabbit_Legendary.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -8720768394999697586}
   m_Layer: 0
   m_Name: 304_Rabbit_Legendary
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 5
   attackDamage: 50
   attackCooldown: 1
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-8720768394999697586
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/400_Capybara_Nomal.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/400_Capybara_Nomal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -747215727430530590}
   m_Layer: 0
   m_Name: 400_Capybara_Nomal
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3
   attackDamage: 10
   attackCooldown: 5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-747215727430530590
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/401_Capybara_Rare.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/401_Capybara_Rare.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 591748812558020954}
   m_Layer: 0
   m_Name: 401_Capybara_Rare
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3.5
   attackDamage: 20
   attackCooldown: 4
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &591748812558020954
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/402_Capybara_Epic.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/402_Capybara_Epic.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -8027669609178724727}
   m_Layer: 0
   m_Name: 402_Capybara_Epic
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4
   attackDamage: 30
   attackCooldown: 3
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-8027669609178724727
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/403_Capybara_Unique.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/403_Capybara_Unique.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 3441705570407830536}
   m_Layer: 0
   m_Name: 403_Capybara_Unique
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4.5
   attackDamage: 4
   attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &3441705570407830536
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/404_Capybara_Legendary.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/404_Capybara_Legendary.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -3074999089212900034}
   m_Layer: 0
   m_Name: 404_Capybara_Legendary
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 5
   attackDamage: 50
   attackCooldown: 1
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-3074999089212900034
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/500_Panda_Nomal.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/500_Panda_Nomal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -8057138012044827542}
   m_Layer: 0
   m_Name: 500_Panda_Nomal
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3
   attackDamage: 10
   attackCooldown: 5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-8057138012044827542
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/501_Panda_Rare.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/501_Panda_Rare.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -7603361990531208079}
   m_Layer: 0
   m_Name: 501_Panda_Rare
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 3.5
   attackDamage: 20
   attackCooldown: 4
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-7603361990531208079
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/502_Panda_Epic.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/502_Panda_Epic.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: -5204217706413682252}
   m_Layer: 0
   m_Name: 502_Panda_Epic
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4
   attackDamage: 30
   attackCooldown: 3
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &-5204217706413682252
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/503_Panda_Unique.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/503_Panda_Unique.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 6135937982476626349}
   m_Layer: 0
   m_Name: 503_Panda_Unique
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 4.5
   attackDamage: 4
   attackCooldown: 2
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &6135937982476626349
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0

--- a/X_Suvivor_prototype/Assets/Prefabs/Pet/504_Panda_Legendary.prefab
+++ b/X_Suvivor_prototype/Assets/Prefabs/Pet/504_Panda_Legendary.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1403403722560252523}
   - component: {fileID: 3528144728598297618}
   - component: {fileID: 5495237886329258799}
+  - component: {fileID: 5699363984140452278}
   m_Layer: 0
   m_Name: 504_Panda_Legendary
   m_TagString: Untagged
@@ -113,7 +114,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!95 &3528144728598297618
 Animator:
   serializedVersion: 5
@@ -153,9 +154,45 @@ MonoBehaviour:
   returnDistance: 6
   minWaitTime: 0.3
   maxWaitTime: 1
+  maxHealth: 5
   attackRange: 5
   attackDamage: 50
   attackCooldown: 1
   enemyLayer:
     serializedVersion: 2
     m_Bits: 64
+--- !u!70 &5699363984140452278
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448656011933182545}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 0.6, y: 0.9}
+  m_Direction: 0


### PR DESCRIPTION
펫 기본 체력 5
현재 체력이 0이 될 시 '넉다운(사망)'
이동 로직 개선 : 플레이어 주변을 아무 위치로 움직임 -> 주변의 적의 수에 따라 '위협 강도'를 판단, 제일 위협이 적은 위치로 이동(회피성 부여)